### PR TITLE
Handle propName() setter-getters without signature

### DIFF
--- a/PropertyAccessor.php
+++ b/PropertyAccessor.php
@@ -634,7 +634,8 @@ class PropertyAccessor implements PropertyAccessorInterface
             if ($this->isMethodAccessible($reflClass, $setter, 1)) {
                 $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
                 $access[self::ACCESS_NAME] = $setter;
-            } elseif ($this->isMethodAccessible($reflClass, $getsetter, 1)) {
+            } elseif ($this->isMethodAccessible($reflClass, $getsetter, 1)
+                      || $this->isMethodAccessible($reflClass, $getsetter, 0)) {
                 $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
                 $access[self::ACCESS_NAME] = $getsetter;
             } elseif ($this->isMethodAccessible($reflClass, '__set', 2)) {

--- a/Tests/Fixtures/TestClassSetterGetter.php
+++ b/Tests/Fixtures/TestClassSetterGetter.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+
+/**
+ * @property mixed emptySignature
+ * @property mixed withSignature
+ */
+class TestClassSetterGetter
+{
+
+    private $emptySignature;
+    private $withSignature;
+
+
+    /**
+     * Cute helper that assigns a variable when called with two arguments.
+     * The idea is to avoid two mutators for most (if not all) fields.
+     *
+     * Example:
+     *
+     *      class Foo
+     *      {
+     *          use TimeTracking\Trait\SetOrGetTrait;
+     *          public function bar()
+     *          {
+     *              return $this->setOrGet(func_get_args(), $this->barProperty);
+     *          }
+     *      }
+     *
+     * @param array $callersArgv parameters of the function that called us.
+     * @param mixed $targetProperty address of the property that will be assigned to.
+     * @return static|mixed
+     */
+    protected function setOrGet($callersArgv, &$targetProperty) {
+        if (count($callersArgv) > 0) {
+            $targetProperty = $callersArgv[0];
+            return $this;
+        }
+        return $targetProperty;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function withSignature($foo = null) {
+        return $this->setOrGet(func_get_args(), $this->withSignature);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function emptySignature() {
+        return $this->setOrGet(func_get_args(), $this->emptySignature);
+    }
+}

--- a/Tests/PropertyAccessorTest.php
+++ b/Tests/PropertyAccessorTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassIsWritable;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicCall;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicGet;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassSetterGetter;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassSetValue;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassTypeErrorInsideCall;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\Ticket5775Object;
@@ -419,6 +420,30 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor = new PropertyAccessor(true);
 
         $this->assertTrue($this->propertyAccessor->isWritable(new TestClassMagicCall('Bernhard'), 'magicCallProperty'));
+    }
+
+    public function testIsWritableRecognizesSetterGetter()
+    {
+        $this->propertyAccessor = new PropertyAccessor();
+        $sg = new TestClassSetterGetter();
+        $this->assertTrue($this->propertyAccessor->isWritable($sg, 'withSignature'), 'setterGetter($j = null)');
+        $this->assertTrue($this->propertyAccessor->isWritable($sg, 'emptySignature'), 'setterGetter()');
+    }
+
+    public function testSetterGetterRead()
+    {
+        $sg = (new TestClassSetterGetter)->withSignature('cake')->emptySignature('cake');
+        $this->assertEquals('cake', $this->propertyAccessor->getValue($sg, 'withSignature'));
+        $this->assertEquals('cake', $this->propertyAccessor->getValue($sg, 'emptySignature'));
+    }
+
+    public function testSetterGetterWrite()
+    {
+        $sg = new TestClassSetterGetter;
+        $this->propertyAccessor->setValue($sg, 'withSignature', 'cake');
+        $this->propertyAccessor->setValue($sg, 'emptySignature', 'cake');
+        $this->assertEquals('cake', $sg->withSignature());
+        $this->assertEquals('cake', $sg->emptySignature());
     }
 
     /**


### PR DESCRIPTION
There are two comments in the PropertyAccessor implying that
setters without signature should be supported:

    // jQuery style, e.g. read: last(), write: last($item)

The `getWriteAccessInfo(<class>, <property>, <value>)` method should
take this into account and recognize a setter-getter without a
signature by calling `isMethodAccessible(<class>, <method>, 0)`