### PR TITLE
Index with dot

### DIFF
--- a/PropertyPath.php
+++ b/PropertyPath.php
@@ -142,7 +142,11 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         $parent = clone $this;
 
         --$parent->length;
-        $parent->pathAsString = substr($parent->pathAsString, 0, max(strrpos($parent->pathAsString, '.'), strrpos($parent->pathAsString, '[')));
+        if (substr($parent->pathAsString, -1) == ']') {
+            $parent->pathAsString = substr($parent->pathAsString, 0, strrpos($parent->pathAsString, '['));
+        } else {
+            $parent->pathAsString = substr($parent->pathAsString, 0, strrpos($parent->pathAsString, '.'));
+        }        
         array_pop($parent->elements);
         array_pop($parent->isIndex);
 

--- a/Tests/PropertyPathTest.php
+++ b/Tests/PropertyPathTest.php
@@ -98,6 +98,13 @@ class PropertyPathTest extends TestCase
         $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
     }
 
+    public function testGetParentWithDotInIndex()
+    {
+        $propertyPath = new PropertyPath('grandpa.parent[child-2.0]');
+
+        $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
+    }
+
     public function testGetParentWhenThereIsNoParent()
     {
         $propertyPath = new PropertyPath('path');


### PR DESCRIPTION
getParent() does not work if there is a dot in the index of a path (Ex. `parent[child-2.0]`).
